### PR TITLE
Update BrainBoard page

### DIFF
--- a/_data/products/brainboard.yml
+++ b/_data/products/brainboard.yml
@@ -13,7 +13,7 @@ featureCtaLink: /contact
 features:
   - title: Onboard learning
     icon: /img/icon-brain2-red.svg
-  - title: Inexpensive and off-the-shelf
+  - title: Inexpensive and <br /> off-the-shelf
     icon: /img/icon-board.svg
   - title: Use with any Nengo model
     icon: /img/icon-models.svg
@@ -33,10 +33,10 @@ ctas:
       together.
     link: http://forum.nengo.ai
     linkText: Visit the forum
-  - title: Purchase a board
+  - title: Purchase a license
     description: >
-      We offer complete hardware and software packages, or we can
-      provide software for your hardware.
+      We offer complete hardware and software integration with
+      a bring-your-own-board model.
     link: /contact
     linkText: Contact us
 
@@ -51,10 +51,13 @@ research:
     Xilinx FPGAs. This will provide a quick route to get the benefits
     of neuromorphic computing sooner rather than later.
 
-    This project is still in the early stages, but has already
-    generated promising results, showing significantly better
-    performance for high bandwidth and compute intensive use
-    cases. Given the large scale, we're working with collaborators to
+    Given the large scale, we're working with collaborators to
     develop special communication protocols to move spiking data
-    efficiently on chip.
+    efficiently on chip. This project is still in the early stages,
+    but has already generated promising results, showing significantly
+    better performance for high bandwidth and compute intensive use
+    cases. Take a look at
+    [this conference paper](http://compneuro.uwaterloo.ca/publications/morcos2018.html)
+    for more information about the design and performance of our
+    early Pynq implementation of Nengo Brain Board.
 ---

--- a/products/brainboard.md
+++ b/products/brainboard.md
@@ -19,5 +19,5 @@ most laptops in terms of both speed and efficiency.
 
 Start by running one of the many demos
 that come with the board out of the box:
-adaptive controllers, visual classifiers,
-voice recognizers, and many more.
+visual classifiers, adaptive controllers,
+reinforcement learning, and more!


### PR DESCRIPTION
**What I did**
Did a quick review of the Brain Board product page.

- Updated demo callouts in description to match NengoFPGA examples
- Added line break to keep "off-the-shelf" together in features list
- Update "purchase a board" to "purchase a license" with BYOBoard
- Add link to paper in research section

**Tested?**

I built the site locally and it looks good.

**What about this though...**

I did not include the [paper presentation](https://github.com/bmorcos/presentations/blob/master/FPT18/NEF_on_PYNQ_FPT18.pdf). It _does_ have more information than the paper itself, but I'm not sure if we want to include it here. Looking for opinions.