### PR TITLE
Add purchase link to Brain Board page

### DIFF
--- a/_data/products/brainboard.yml
+++ b/_data/products/brainboard.yml
@@ -8,7 +8,7 @@ shortDescription: >
   Explore and exploit the advantages of neuromorphic computing
   in the classroom, the innovation lab, or your basement.
 
-featureCtaText: Contact us to purchase
+featureCtaText: Contact us with questions
 featureCtaLink: /contact
 features:
   - title: Onboard learning
@@ -37,8 +37,8 @@ ctas:
     description: >
       We offer complete hardware and software integration with
       a bring-your-own-board model.
-    link: /contact
-    linkText: Contact us
+    link: https://applied-brain-research-inc.myshopify.com/collections/nengo-fpga
+    linkText: Purchase online
 
 research:
   title: Large-scale Nengo Brain Boards


### PR DESCRIPTION
The Shopify store is now live, so I updated the Brain Board page with a purchase link.