### PR TITLE
Add nengo-spa 1.1.0 and 1.0.1 versions

### DIFF
--- a/_releases/nengo-spa.md
+++ b/_releases/nengo-spa.md
@@ -3,6 +3,10 @@ name: Nengo SPA
 external_url: https://www.nengo.ai/nengo-spa/
 latest: 2019-12-08
 versions:
+  - version: 1.1.0
+    external_url: https://forum.nengo.ai/t/nengo-spa-1-1-0-released/1213
+  - version: 1.0.1
+    external_url: https://github.com/nengo/nengo-spa/releases/tag/v1.0.1
   - version: 1.0.0
     external_url: https://forum.nengo.ai/t/nengo-spa-1-0-0-released/1026
   - version: 0.6.2


### PR DESCRIPTION
Is it really required to add all bugfix releases to this list?

Wouldn't it be possible to automatically generate that list? I suppose the forum URL might be a problem for that?