### PR TITLE
Add publications category for news page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,8 @@ collections:
       - nature.md
       - neurogrid.md
       - natgeo.md
+  papers:
+    output: true
   press:
     output: true
   products:

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -5,14 +5,26 @@ layout: default
 <div class="main-content gradient-top">
   <div class="container news">
     <div class="col-10 col-lg-10 col-xl-10 text-center py-5 news-title">
-      <h1 class="display-6">{{ page.title }}</h3>
-      <p class="lead m-0">{{ page.date | date: "%b %d, %Y" }}{% if page.author %}, {{ page.author }}{% endif %}</p>
+      <h1 class="display-6">{{ page.title }}</h1>
+      <p class="m-0">
+        {% if page.collection == "blog" %}
+        <span class="badge bg-red text-white">Blog post</span>
+        {% elsif page.collection == "external" %}
+        <span class="badge bg-purple text-white">External</span>
+        {% elsif page.collection == "papers" %}
+        <span class="badge bg-dark text-white">Research</span>
+        {% elsif page.collection == "press" %}
+        <span class="badge bg-primary text-white">Press release</span>
+        {% endif %}
+        <small>
+          posted {{ page.date | date: "%b %d, %Y" }}{% if page.author %} by {{
+          page.author }}{% endif %}
+        </small>
+      </p>
       <div class="title-bar"></div>
     </div>
     <div class="row justify-content-center my-5">
-      <div class="col-10 col-lg-10 col-xl-10">
-        {{ content }}
-      </div>
+      <div class="col-10 col-lg-10 col-xl-10">{{ content }}</div>
     </div>
   </div>
 </div>

--- a/_papers/2018-12-04-loihi-kws.md
+++ b/_papers/2018-12-04-loihi-kws.md
@@ -1,0 +1,26 @@
+---
+layout: news
+title: Benchmarking keyword spotting efficiency on neuromorphic hardware
+author: Peter Blouw, Xuan Choo, Eric Hunsberger and Chris Eliasmith
+---
+
+Abstract
+--------
+
+Using Intel's Loihi neuromorphic research chip and ABR's Nengo Deep
+Learning toolkit, we analyze the inference speed, dynamic power
+consumption, and energy cost per inference of a two-layer neural
+network keyword spotter trained to recognize a single phrase. We
+perform comparative analyses of this keyword spotter running on more
+conventional hardware devices including a CPU, a GPU, Nvidia's Jetson
+TX1, and the Movidius Neural Compute Stick. Our results indicate that
+for this inference application, Loihi outperforms all of these
+alternatives on an energy cost per inference basis while maintaining
+equivalent inference accuracy. Furthermore, an analysis of tradeoffs
+between network size, inference speed, and energy cost indicates that
+Loihi's comparative advantage over other low-power computing devices
+improves for larger networks.
+
+[<span class="paperlink">Full paper</span>](https://arxiv.org/abs/1812.01739)
+
+[<span class="prlink">Press release</span>]({{ site.baseurl }}{% link _press/2018-12-06-intel.md %})

--- a/_papers/2020-02-10-quantized-activations.md
+++ b/_papers/2020-02-10-quantized-activations.md
@@ -1,0 +1,32 @@
+---
+layout: news
+title: >
+  A spike in performance: training hybrid-spiking neural networks
+  with quantized activation functions
+author: Aaron R. Voelker, Daniel Rasmussen and Chris Eliasmith
+---
+
+Abstract
+--------
+
+The machine learning community has become increasingly interested in
+the energy efficiency of neural networks. The Spiking Neural Network
+(SNN) is a promising approach to energy-efficient computing, since its
+activation levels are quantized into temporally sparse, one-bit values
+(i.e., "spike" events), which additionally converts the sum over
+weight-activity products into a simple addition of weights (one weight
+for each spike). However, the goal of maintaining state-of-the-art
+(SotA) accuracy when converting a non-spiking network into an SNN has
+remained an elusive challenge, primarily due to spikes having only a
+single bit of precision. Adopting tools from signal processing, we
+cast neural activation functions as quantizers with
+temporally-diffused error, and then train networks while smoothly
+interpolating between the non-spiking and spiking regimes. We apply
+this technique to the Legendre Memory Unit (LMU) to obtain the first
+known example of a hybrid SNN outperforming SotA recurrent
+architectures---including the LSTM, GRU, and NRU---in accuracy, while
+reducing activities to at most 3.74 bits on average with 1.26
+significant bits multiplying each weight. We discuss how these methods
+can significantly improve the energy efficiency of neural networks.
+
+[<span class="paperlink">Full paper</span>](https://arxiv.org/abs/2002.03553)

--- a/_papers/2020-05-14-neuromorphic.md
+++ b/_papers/2020-05-14-neuromorphic.md
@@ -1,0 +1,25 @@
+---
+layout: news
+title: Event-driven signal processing with neuromorphic computing systems
+author: Peter Blouw and Chris Eliasmith
+---
+
+Abstract
+--------
+
+Neuromorphic hardware has long promised to provide power advantages by
+leveraging the kind of event-driven, temporally sparse computation
+observed in biological neural systems. Only recently, however, has
+this hardware been developed to a point that allows for general
+purpose AI programming. In this paper, we provide an overview of tools
+and methods for building applications that run on neuromorphic
+computing devices. We then discuss reasons for observed efficiency
+gains in neuromorphic systems, and provide a concrete illustration of
+these gains by comparing conventional and neuromorphic implementations
+of a keyword spotting system trained on the widely used Speech
+Commands dataset. We show that replacing floating point operations in
+a conventional neural network with synaptic operations in a spiking
+neural network results in a roughly 4x energy reduction, with minimal
+performance loss.
+
+[<span class="paperlink">Full paper</span>](https://ieeexplore.ieee.org/abstract/document/9053043)

--- a/_papers/2020-09-09-lmu-kws.md
+++ b/_papers/2020-09-09-lmu-kws.md
@@ -1,0 +1,29 @@
+---
+layout: news
+title: >
+    Hardware aware training for efficient keyword spotting
+    on general purpose and specialized hardware
+author: >
+    Peter Blouw, Gurshaant Malik, Benjamin Morcos, Aaron R. Voelker
+    and Chris Eliasmith
+---
+
+Abstract
+--------
+
+Keyword spotting (KWS) provides a critical user interface for many
+mobile and edge applications, including phones, wearables, and
+cars. As KWS systems are typically 'always on', maximizing both
+accuracy and power efficiency are central to their utility. In this
+work we use hardware aware training (HAT) to build new KWS neural
+networks based on the Legendre Memory Unit (LMU) that achieve
+state-of-the-art (SotA) accuracy and low parameter counts. This allows
+the neural network to run efficiently on standard hardware (212 μW). We
+also characterize the power requirements of custom designed
+accelerator hardware that achieves SotA power efficiency of 8.79 μW,
+beating general purpose low power hardware (a microcontroller) by 24x
+and special purpose ASICs by 16x.
+
+[<span class="paperlink">Full paper</span>](https://arxiv.org/abs/2009.04465)
+
+[<span class="prlink">Press release</span>]({{ site.baseurl }}{% link _press/2020-09-14-lmu-kws.md %})

--- a/_papers/2020-10-09-dewolf-neurorobotics.md
+++ b/_papers/2020-10-09-dewolf-neurorobotics.md
@@ -1,0 +1,44 @@
+---
+layout: news
+title: Nengo and low-power AI hardware for robust, embedded neurorobotics
+author: Travis DeWolf, Pawel Jaworski and Chris Eliasmith
+---
+
+Abstract
+--------
+
+In this paper we demonstrate how the Nengo neural modeling and
+simulation libraries enable users to quickly develop robotic
+perception and action neural networks for simulation on neuromorphic
+hardware using tools they are already familiar with, such as Keras and
+Python. We identify four primary challenges in building robust,
+embedded neurorobotic systems, including: (1) developing
+infrastructure for interfacing with the environment and sensors; (2)
+processing task specific sensory signals; (3) generating robust,
+explainable control signals; and (4) compiling neural networks to run
+on target hardware. Nengo helps to address these challenges by: (1)
+providing the NengoInterfaces library, which defines a simple but
+powerful API for users to interact with simulations and hardware; (2)
+providing the NengoDL library, which lets users use the Keras and
+TensorFlow API to develop Nengo models; (3) implementing the Neural
+Engineering Framework, which provides white-box methods for
+implementing known functions and circuits; and (4) providing multiple
+backend libraries, such as NengoLoihi, that enable users to compile
+the same model to different hardware. We present two examples using
+Nengo to develop neural networks that run on CPUs and GPUs as well as
+Intel's neuromorphic chip, Loihi, to demonstrate two variations on
+this workflow. The first example is an implementation of an end-to-end
+spiking neural network in Nengo that controls a rover simulated in
+Mujoco. The network integrates a deep convolutional network that
+processes visual input from cameras mounted on the rover to track a
+target, and a control system implementing steering and drive functions
+in connection weights to guide the rover to the target. The second
+example uses Nengo as a smaller component in a system that has
+addressed some but not all of those challenges. Specifically it is
+used to augment a force-based operational space controller with neural
+adaptive control to improve performance during a reaching task using a
+real-world Kinova Jaco robotic arm. The code and implementation
+details are provided, with the intent of enabling other researchers to
+build and run their own neurorobotic systems.
+
+[<span class="paperlink">Full paper</span>](https://www.frontiersin.org/articles/10.3389/fnbot.2020.568359/full)

--- a/css/bootstrap.scss
+++ b/css/bootstrap.scss
@@ -350,7 +350,11 @@ ul.service-links {
 
 /* News */
 
-.blog, .external, .press {
+.news-filter button {
+  font-size: 75%;
+}
+
+.blog, .external, .papers, .press, .news {
   .badge {
     text-transform: uppercase;
   }
@@ -361,6 +365,21 @@ ul.service-links {
     margin-left: auto;
     margin-right: auto;
   }
+}
+
+.paperlink, .prlink {
+  font-size: x-large;
+}
+.paperlink:before, .prlink:before {
+    content: "";
+    display: block;
+    background: url("../img/icon-documentation.svg");
+    background-repeat: no-repeat;
+    background-size: 32px;
+    width: 32px;
+    height: 32px;
+    float: left;
+    margin: 0 6px 0 0;
 }
 
 

--- a/news.html
+++ b/news.html
@@ -9,27 +9,40 @@ title: News
     {% include title-block.html title=page.title %}
     <div class="row justify-content-center py-5">
       <div class="col col-md-7 col-sm-10 mb-5">
-        <div class="pb-4">
+        <div class="pb-4 news-filter">
           <button class="btn btn-primary text-white" data-id="all" onclick="changeFilter(this);">All</button>
           <button class="btn btn-primary text-white" data-id="press" onclick="changeFilter(this);">Press releases</button>
+          <button class="btn btn-primary text-white" data-id="papers" onclick="changeFilter(this);">Research</button>
           <button class="btn btn-primary text-white" data-id="blog" onclick="changeFilter(this);">Blog posts</button>
-          <button class="btn btn-primary text-white" data-id="external" onclick="changeFilter(this);">External link</button>
+          <button class="btn btn-primary text-white" data-id="external" onclick="changeFilter(this);">External links</button>
         </div>
-        {% assign posts = site.blog | concat: site.external | concat: site.press | sort: "date" | reverse %}
+        {% assign posts = site.blog
+           | concat: site.external
+           | concat: site.press
+           | concat: site.papers
+           | sort: "date"
+           | reverse
+        %}
         {% for post in posts %}
         <div class="mb-5 {{ post.collection }}">
-          <h4><a href="{{ post.external_url | default: post.url }}">
+          <h4>
+            <a href="{{ post.external_url | default: post.url }}">
               {{ post.title }}
-          </a></h4>
+            </a>
+          </h4>
           <p class="mb-1">
             {% if post.collection == "blog" %}
               <span class="badge bg-red text-white">Blog post</span>
             {% elsif post.collection == "external" %}
               <span class="badge bg-purple text-white">External</span>
+            {% elsif post.collection == "papers" %}
+              <span class="badge bg-dark text-white">Research</span>
             {% elsif post.collection == "press" %}
               <span class="badge bg-primary text-white">Press release</span>
             {% endif %}
-            {{ post.date | date: "%b %d, %Y" }}{% if post.author %}, {{ post.author }}{% endif %}
+            <small>
+              posted {{ post.date | date: "%b %d, %Y" }}{% if post.author %} by {{ post.author }}{% endif %}
+            </small>
           </p>
         </div>
         {% endfor %}
@@ -97,7 +110,7 @@ title: News
 
 <script>
   const changeFilter = (btn) => {
-    const all = ['press', 'blog', 'external'];
+    const all = ['papers', 'press', 'blog', 'external'];
     const selectedFilter = btn.getAttribute('data-id');
 
     all.forEach(filter => {


### PR DESCRIPTION
This adds a "Publications" category for news items, that allows us to group publications.

Open questions:
- What do we want to call this section? I'm calling it `papers` in the code for brevity, and "publications" on the user-facing side since that's a bit more general, a bit clearer, and a bit more professional.
- What colour should the badge be? I've currently made it charcoal (`bg-dark`), since that was an existing colour (in `bootstrap.css`) not used for any of our other categories, and makes it stand out more than `bg-green`, which matches the text.
- What do we want each publication page to look like? I've been copying in the abstract, and then putting a link to the full paper. I've made the link decently large and used an existing icon. I've also added links to an associated press release when there is one. Do we want any other additional information (copyable citation, bibtex, link straight to PDF, some background/context/promotion)?
- Should we put the paper authors as the news item authors? That's what I've been doing so far.
- What order do we want the buttons to show different categories on the news page? I've put "Publications" second, right after "Press Releases", since publications seem more significant than blog posts and external links.
- Do we want to denote in the "Full paper" link text when the full paper is behind a paywall versus freely available?

TODO:
- [x] Go through past publications and add them