### PR TITLE
Fix broken links

### DIFF
--- a/_blog/2016-05-10-chris-at-tlc.md
+++ b/_blog/2016-05-10-chris-at-tlc.md
@@ -6,7 +6,7 @@ author: Trevor Bekolay
 
 <p class="lead">
   ABR co-CEO Chris Eliasmith will be talking at this year's
-  <a href="https://techleadership.ca">Tech Leadership Conference</a>
+  Tech Leadership Conference
   in Kitchener-Waterloo on May 12, 2016.
 </p>
 

--- a/_blog/2017-05-11-abr-demos-to-justin-trudeau.md
+++ b/_blog/2017-05-11-abr-demos-to-justin-trudeau.md
@@ -45,7 +45,7 @@ under the supervision of Dr. Eliasmith
 at the University of Waterloo's Centre for Theoretical Neuroscience,
 and has since been extended and patented by ABR.
 The original research was
-[published in November, 2016](http://rspb.royalsocietypublishing.org/content/283/1843/20162134),
+[published in November, 2016](https://royalsocietypublishing.org/doi/full/10.1098/rspb.2016.2134),
 and Reach is now being advanced
 to increase its tool manipulation abilities
 for use in commercial applications.

--- a/_press/2019-12-27-ces.md
+++ b/_press/2019-12-27-ces.md
@@ -117,7 +117,7 @@ co-CEO<br>
 - Lazaridis Institute Cohort 2019 -
   <https://www.wlu.ca/news/news-releases/2018/sept/10-companies-join-lazaridis-scale-up-program.html>
 - 48 Hrs In the Valley 2019 -
-  <https://www.thec100.org/48hrs-in-the-valley>
+  <https://www.thec100.org/48hrs-alumni>
 - CTA Program 2019 -
   <https://www.evensi.ca/cta-mentor-meet-toronto-2018-oneeleven/274571157>
 - VentureBeat Transform Tech Showcase 2018 -


### PR DESCRIPTION
The links to the conferences were just gone, so I removed them (they're old, anyway). The TLC one tries to redirect to TrueNorth, but ends up completely mangled (even Google has it wrong, and I can't find any other page about TrueNorth).