### PR TITLE
Remove dead BCR article link

### DIFF
--- a/_external/2013-06-20-biomedical-computation.md
+++ b/_external/2013-06-20-biomedical-computation.md
@@ -1,5 +1,0 @@
----
-title: Dr. Eliasmith on Spaun relationship to the connectome
-author: Biomedical Computation Review
-external_url: http://www.bcr.org/content/behind-connectome-commotion
----


### PR DESCRIPTION
This link is dead. My inclination is to just remove it, as I can't find an active alternative, though it is available through the archive: https://web.archive.org/web/20210118223040/https://bcr.org/content/behind-connectome-commotion